### PR TITLE
ARRRmada provides new donation button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,6 @@
 	<link rel="shortcut icon" href="img/icons/favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Bai Jamjuree:300,400,500,700,400italic">
 	<link rel="stylesheet" href="css/main.min.css">
-        <link rel="stylesheet" href="https://pirate.black/donate_arrr/donate_arrr.css">
   <link rel="stylesheet" href="css/common.min.css">
 <script src="https://widgets.coingecko.com/coingecko-coin-ticker-widget.js"></script>
 <meta name="theme-color" content="#BB9645">
@@ -103,7 +102,6 @@
 	<script src="js/vendors.min.js"></script>
 	<script src="js/angularjs-all.min.js"></script>
 	<script src="js/main.min.js"></script>
-        <script src="https://pirate.black/donate_arrr/donate_arrr.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </body>
 </html>

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -72,9 +72,18 @@ Pirate (ARRR) is a 100% private cryptocurrency. PIRATE uses a privacy protocol t
         <a class="twitter-timeline" href="https://twitter.com/PirateChain"  target="_blank">Tweets by PirateChain</a></p>
         <div id="powered" class="row">
          
-          <center><img src="img/pirate.png" width="300px"><br>
-           <a href="piratechain:zs1sv7m6s76d00pkhyshw05hafgxczuykt3s573fr7ea8sr84x03pwdhdhhqa4sjtd26vf9u8jht64"><img class="" src="https://pirate.black/donate-pirate" width="199" height="69" /></a>
-          </center>
+          <div class="donation-container">
+    <a class="donation-link"
+       title="click to donate ARRR"
+       href="pirate:zs1sv7m6s76d00pkhyshw05hafgxczuykt3s573fr7ea8sr84x03pwdhdhhqa4sjtd26vf9u8jht64">
+        <img class="donation-image"
+             alt="ARRR donation button"
+             src="https://arrrmada.com/button/donateARRR1.png"
+             width="200px" height="auto" />
+    </a>
+    <div class="qrcode-popup"></div>
+</div>
+<script defer src="https://arrrmada.com/button/donate_arrr.js"></script>
         </div>
       </div> <!-- END OF COL-3 -->
     </div>


### PR DESCRIPTION
The old donation script is getting on in years and will therefore be replaced by the new option, which is located on ARRRmada.com.
I have removed the old ones and replaced them with the new ones, taking over the Explorer donation address (zs1sv7m6s76d00pkhyshw05hafgxczuykt3s573fr7ea8sr84x03pwdhdhhqa4sjtd26vf9u8jht64). Please check beforehand if the key is still there.

Btw.
Maybe we should take out the Changelly and Twitter script to streamline Explorer.

Best Regards